### PR TITLE
Fix keyword-only dependency handling

### DIFF
--- a/src/versatile/component_builder.py
+++ b/src/versatile/component_builder.py
@@ -16,7 +16,11 @@ class ComponentBuilder:
     def build(
         self, provider: ComponentProvider, dependencies: dict[str, Any]
     ) -> MaterialisedComponent:
-        component_obj = provider.func(*dependencies.values())
+        call_kwargs = {
+            dep.parameter_name: dependencies[dep.component_name]
+            for dep in provider.dependencies
+        }
+        component_obj = provider.func(**call_kwargs)
 
         untransformed = MaterialisedComponent(
             uuid.uuid4(),

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -181,3 +181,18 @@ def test_raises_if_child_component_aliases_parent():
         match=r"Provider names .* conflict with component in parent bundle",
     ):
         make_bundle(child_registry, parent=parent_bundle)
+
+
+def test_keyword_only_dependency():
+    registry = ComponentProviderRegistry()
+
+    @registry.provides("foo")
+    def make_foo() -> str:
+        return "foo"
+
+    @registry.provides("bar")
+    def make_bar(*, foo: Annotated[str, "foo"]) -> str:
+        return f"bar-{foo}"
+
+    bundle = make_bundle(registry)
+    assert bundle["bar"] == "bar-foo"


### PR DESCRIPTION
## Summary
- pass dependencies as keyword arguments when building components
- test keyword-only dependency resolution

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aa583e8e08331bf5ba9b97f28eeb6